### PR TITLE
Analyze deployment failure logs

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,58 @@
+# Git
+.git
+.gitignore
+
+# Python
+__pycache__
+*.pyc
+*.pyo
+*.pyd
+.Python
+env
+venv
+pip-log.txt
+pip-delete-this-directory.txt
+.tox
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.log
+.pytest_cache
+
+# Frontend (not needed for backend)
+frontend/
+node_modules/
+
+# Data and models (excluding maia_weights which is needed)
+data_generators/
+blunder_prediction/
+move_prediction/
+
+# Documentation
+*.md
+LICENSE
+CITATION.cff
+images/
+
+# Development files
+docker-compose.yml
+maia_env.yml
+pytest.ini
+project_assessment_report.md
+
+# IDE
+.vscode
+.idea
+*.swp
+*.swo
+*~
+
+# OS
+.DS_Store
+Thumbs.db
+
+# Render specific
+render.yaml

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -42,13 +42,17 @@ RUN set -eux; \
 WORKDIR /app
 
 # Copy requirements first to leverage Docker cache
-COPY requirements.txt .
+# Since the Dockerfile is in backend/, we need to copy from backend/requirements.txt
+COPY backend/requirements.txt .
 
 # Install Python dependencies
 RUN pip install --no-cache-dir --trusted-host pypi.org --trusted-host pypi.python.org --trusted-host files.pythonhosted.org -r requirements.txt
 
-# Copy application code
-COPY . .
+# Copy only the backend directory contents
+COPY backend/ .
+
+# Copy the model weights from the root directory
+COPY maia_weights/ ./maia_weights/
 
 # Expose port 5000
 EXPOSE 5000


### PR DESCRIPTION
Fix Docker build context and include model weights to resolve `ModuleNotFoundError` during Render deployment.

The `ModuleNotFoundError: No module named 'app'` occurred because the Dockerfile in `backend/` was built from the project root, causing `app.py` to be copied to `/app/backend/app.py` instead of `/app/app.py`. This PR adjusts `COPY` commands in the Dockerfile and adds a `.dockerignore` to ensure correct file placement and inclusion of necessary model weights (`maia_weights/`).