### PR TITLE
Investigate deployment worker timeout errors

### DIFF
--- a/RENDER_DEPLOYMENT_FIX.md
+++ b/RENDER_DEPLOYMENT_FIX.md
@@ -1,0 +1,57 @@
+# Render Deployment Fix
+
+## Issue
+The Gunicorn workers were timing out during startup on Render, showing errors like:
+- `WORKER TIMEOUT (pid:XX)`
+- `Worker (pid:XX) was sent SIGKILL! Perhaps out of memory?`
+
+## Root Cause
+The TensorFlow library was being imported during module initialization in `maia_engine.py`, even though it wasn't actually being used. TensorFlow has a very slow initialization process (25-30+ seconds), which exceeded Gunicorn's default 30-second worker timeout.
+
+## Fixes Applied
+
+### 1. Increased Gunicorn Worker Timeout
+Modified `backend/Dockerfile` to add a 120-second timeout:
+```dockerfile
+CMD ["gunicorn", "--bind", "0.0.0.0:5000", "--workers", "2", "--timeout", "120", "app:app"]
+```
+
+### 2. Removed Unused TensorFlow Import
+- Commented out the TensorFlow import in `backend/maia_engine.py` since the current implementation uses lc0 (Leela Chess Zero) instead of TensorFlow models
+- Removed `tensorflow-cpu==2.12.0` from `backend/requirements.txt`
+
+## Additional Optimization Options
+
+If you need to use TensorFlow in the future, consider these options:
+
+### Option 1: Lazy Loading
+Only import TensorFlow when actually needed:
+```python
+def some_function_that_needs_tf():
+    import tensorflow as tf  # Import only when needed
+    # Use TensorFlow here
+```
+
+### Option 2: Preload Application
+Use Gunicorn's preload feature to load the application once before forking workers:
+```dockerfile
+CMD ["gunicorn", "--bind", "0.0.0.0:5000", "--workers", "2", "--timeout", "120", "--preload", "app:app"]
+```
+
+### Option 3: Reduce Worker Count
+For memory-constrained environments, reduce to 1 worker:
+```dockerfile
+CMD ["gunicorn", "--bind", "0.0.0.0:5000", "--workers", "1", "--timeout", "120", "app:app"]
+```
+
+### Option 4: Use Lighter Alternative
+Consider using TensorFlow Lite or ONNX Runtime for inference if you need neural network support in the future.
+
+## Verification
+After these changes, the deployment should:
+1. Start successfully without worker timeouts
+2. Use less memory (no TensorFlow overhead)
+3. Start faster (no 25+ second TensorFlow initialization)
+
+## Memory Considerations
+Render's free tier has limited memory (512MB). The current setup with lc0 and 2 workers should fit comfortably within these limits.

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -58,4 +58,4 @@ COPY maia_weights/ ./maia_weights/
 EXPOSE 5000
 
 # Use gunicorn for production
-CMD ["gunicorn", "--bind", "0.0.0.0:5000", "--workers", "2", "app:app"]
+CMD ["gunicorn", "--bind", "0.0.0.0:5000", "--workers", "2", "--timeout", "120", "app:app"]

--- a/backend/maia_engine.py
+++ b/backend/maia_engine.py
@@ -11,10 +11,12 @@ import subprocess
 from functools import lru_cache
 
 # TensorFlow is optional for future upgrades – import but don't fail hard.
-try:
-    import tensorflow as tf  # type: ignore  # noqa: F401
-except Exception:  # pragma: no cover
-    pass
+# Note: TensorFlow is currently not used, so we're commenting it out to avoid
+# the initialization overhead that causes Gunicorn worker timeouts
+# try:
+#     import tensorflow as tf  # type: ignore  # noqa: F401
+# except Exception:  # pragma: no cover
+#     pass
 
 import chess
 import chess.engine  # type: ignore

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -2,7 +2,6 @@ flask==2.3.3
 python-chess==1.999
 gunicorn==21.2.0
 numpy==1.23.5
-tensorflow-cpu==2.12.0
 protobuf==3.20.3
 pytz
 humanize


### PR DESCRIPTION
Fix Render deployment timeout by removing unused TensorFlow import and increasing Gunicorn timeout.

Gunicorn workers were timing out during deployment because TensorFlow, though unused by the application's current logic, was being imported during module initialization. This caused a 25-30+ second startup delay, exceeding the default 30-second Gunicorn worker timeout. Removing the unused import and increasing the timeout resolves this issue.