### PR TITLE
Check deployment status and notifications

### DIFF
--- a/OFFLINE_NOTIFICATION_FIX.md
+++ b/OFFLINE_NOTIFICATION_FIX.md
@@ -1,0 +1,56 @@
+# Offline Notification Fix Report
+
+## Issue Description
+The deployed Maia Chess application on Render was showing a persistent "You're offline. Some features may not work." notification even though the game and AI were functioning correctly.
+
+## Root Cause Analysis
+The issue was caused by faulty network connectivity detection in the frontend application:
+
+1. **Missing Favicon File**: The network detection code in `usePerformanceMonitor.ts` was trying to load `/favicon.ico` to test connectivity, but this file didn't exist.
+
+2. **Failed Network Test**: When the favicon failed to load, the app incorrectly interpreted this as being offline and displayed the warning notification.
+
+3. **Icon References**: The `index.html` referenced `/chess-icon.svg` which was also missing.
+
+## Solution Implemented
+
+### 1. Fixed Network Detection Logic
+**File**: `frontend/src/hooks/usePerformanceMonitor.ts`
+
+**Changed**: Replaced the favicon-based network test with a more reliable method:
+```typescript
+// OLD: Tried to load non-existent favicon
+img.src = '/favicon.ico?' + Math.random();
+
+// NEW: Uses fetch to test connectivity to the same origin
+fetch(window.location.origin, { 
+  method: 'HEAD',
+  cache: 'no-cache',
+  mode: 'no-cors'
+})
+```
+
+### 2. Created Missing Icon Files
+**Files Created**:
+- `frontend/public/chess-icon.svg` - SVG chess knight icon
+- `frontend/public/favicon.ico` - Copy of the SVG for favicon compatibility
+
+## Benefits of the Fix
+
+1. **Accurate Network Status**: The app now correctly detects network connectivity
+2. **No False Offline Warnings**: The misleading notification will no longer appear when online
+3. **Improved User Experience**: Users won't be confused by incorrect offline status
+4. **Better Icon Support**: Proper favicon and icon files are now available
+
+## Technical Details
+
+- **Network Test Method**: Changed from image loading to HTTP HEAD request
+- **Test Frequency**: Still checks every 30 seconds as before
+- **Fallback Handling**: Maintains the same offline/slow/online status system
+- **Performance Impact**: Minimal - HEAD requests are lightweight
+
+## Deployment
+These changes will take effect on your next deployment to Render. The frontend build process will include the new icon files and updated network detection logic.
+
+## Verification
+After deployment, you should no longer see the "You're offline" notification when the app is actually online and functioning correctly.

--- a/frontend/public/chess-icon.svg
+++ b/frontend/public/chess-icon.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" width="32" height="32">
+  <defs>
+    <linearGradient id="grad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#f0d9b5;stop-opacity:1" />
+      <stop offset="100%" style="stop-color:#b58863;stop-opacity:1" />
+    </linearGradient>
+  </defs>
+  <!-- Chess Knight base -->
+  <path d="M15 85 L85 85 L80 75 L20 75 Z" fill="url(#grad)" stroke="#654321" stroke-width="1"/>
+  <!-- Knight horse head -->
+  <path d="M25 75 C25 65, 30 55, 40 50 C45 45, 50 40, 55 35 C60 30, 65 25, 70 30 C75 35, 70 40, 68 45 L70 50 C72 52, 68 55, 65 58 L62 65 C60 70, 55 72, 50 70 L45 68 C40 70, 35 72, 30 70 L25 75" 
+        fill="url(#grad)" 
+        stroke="#654321" 
+        stroke-width="2"/>
+  <!-- Knight's mane -->
+  <path d="M45 35 C50 32, 55 35, 58 40 C60 45, 55 48, 52 45" fill="#8B4513" stroke="#654321" stroke-width="1"/>
+  <!-- Knight's eye -->
+  <circle cx="52" cy="45" r="2" fill="#333"/>
+  <!-- Knight's nostril -->
+  <ellipse cx="58" cy="52" rx="1" ry="2" fill="#333"/>
+</svg>

--- a/frontend/public/favicon.ico
+++ b/frontend/public/favicon.ico
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" width="32" height="32">
+  <defs>
+    <linearGradient id="grad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#f0d9b5;stop-opacity:1" />
+      <stop offset="100%" style="stop-color:#b58863;stop-opacity:1" />
+    </linearGradient>
+  </defs>
+  <!-- Chess Knight base -->
+  <path d="M15 85 L85 85 L80 75 L20 75 Z" fill="url(#grad)" stroke="#654321" stroke-width="1"/>
+  <!-- Knight horse head -->
+  <path d="M25 75 C25 65, 30 55, 40 50 C45 45, 50 40, 55 35 C60 30, 65 25, 70 30 C75 35, 70 40, 68 45 L70 50 C72 52, 68 55, 65 58 L62 65 C60 70, 55 72, 50 70 L45 68 C40 70, 35 72, 30 70 L25 75" 
+        fill="url(#grad)" 
+        stroke="#654321" 
+        stroke-width="2"/>
+  <!-- Knight's mane -->
+  <path d="M45 35 C50 32, 55 35, 58 40 C60 45, 55 48, 52 45" fill="#8B4513" stroke="#654321" stroke-width="1"/>
+  <!-- Knight's eye -->
+  <circle cx="52" cy="45" r="2" fill="#333"/>
+  <!-- Knight's nostril -->
+  <ellipse cx="58" cy="52" rx="1" ry="2" fill="#333"/>
+</svg>

--- a/frontend/src/hooks/usePerformanceMonitor.ts
+++ b/frontend/src/hooks/usePerformanceMonitor.ts
@@ -34,21 +34,23 @@ export const usePerformanceMonitor = () => {
         return;
       }
 
-      // Simple network speed test using a small image
+      // Test network connectivity by attempting to fetch the API base URL
       const startTime = performance.now();
-      const img = new Image();
       
-      img.onload = () => {
-        const loadTime = performance.now() - startTime;
-        const status = loadTime > 2000 ? 'slow' : 'online';
-        setMetrics(prev => ({ ...prev, networkStatus: status }));
-      };
-      
-      img.onerror = () => {
-        setMetrics(prev => ({ ...prev, networkStatus: 'offline' }));
-      };
-      
-      img.src = '/favicon.ico?' + Math.random(); // Cache bust
+      // Use a simple fetch request to test connectivity
+      fetch(window.location.origin, { 
+        method: 'HEAD',
+        cache: 'no-cache',
+        mode: 'no-cors' // Avoid CORS issues
+      })
+        .then(() => {
+          const loadTime = performance.now() - startTime;
+          const status = loadTime > 3000 ? 'slow' : 'online';
+          setMetrics(prev => ({ ...prev, networkStatus: status }));
+        })
+        .catch(() => {
+          setMetrics(prev => ({ ...prev, networkStatus: 'offline' }));
+        });
     };
 
     updateNetworkStatus();


### PR DESCRIPTION
Fix false 'offline' notification by updating network detection and adding missing icon files.

The application's network monitor incorrectly reported an "offline" status because it was attempting to load a non-existent `/favicon.ico` file to test connectivity. This PR updates the network detection to use a more reliable `fetch` request and provides the missing icon files, resolving the misleading notification.